### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 The official ARC (annotated research context) website!
 
-[nfdi4plants.github.io/arc-website/]([nfdi4plants.github.io/arc-website/](https://nfdi4plants.github.io/arc-website/))
+[nfdi4plants.github.io/arc-website/](https://nfdi4plants.github.io/arc-website/)


### PR DESCRIPTION
The link in the README.md was broken. This small change should fix it. I know the website is still accessible on the right-hand side, but the link in the README should also work since this is usually where most people look first.